### PR TITLE
feat: Add text about pyronear in `AboutModal`

### DIFF
--- a/src/global-components/navbar/AboutModal.tsx
+++ b/src/global-components/navbar/AboutModal.tsx
@@ -2,14 +2,33 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleXmark } from '@fortawesome/free-solid-svg-icons'
 import { ModalInnerComponent } from '../../modals/Modal'
 
-export const AboutModal: ModalInnerComponent = ({ close }: { close: () => void }): JSX.Element => {
+export const AboutModal: ModalInnerComponent = ({
+  close
+}: {
+  close: () => void
+}): JSX.Element => {
   return (
     <>
-      <FontAwesomeIcon icon={faCircleXmark} className='closeIcon' onClick={close}/>
+      <FontAwesomeIcon
+        icon={faCircleXmark}
+        className="closeIcon"
+        onClick={close}
+      />
 
       <h3>A propos de pyronear</h3>
       <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus faucibus, neque eget interdum sagittis, diam orci dapibus erat, id luctus nisl enim a ante. Ut finibus ipsum sit amet diam consectetur, eget sollicitudin dui egestas. Proin non velit non sem auctor maximus. Morbi sit amet placerat odio, quis sodales odio. Mauris euismod leo in tristique elementum. Curabitur at lorem quis justo sollicitudin vehicula sed eget magna. Nam ac ornare leo. Integer quis tincidunt quam. Praesent dapibus sem at justo laoreet, vitae dictum libero placerat. Pellentesque vitae nunc lorem. Integer at nunc mi. Ut accumsan arcu et enim consectetur, vel pharetra arcu tincidunt. Aenean quis magna at arcu tincidunt ultricies non et ante. Donec vel fermentum quam, in blandit metus. In hac habitasse platea dictumst. Aliquam eleifend sagittis euismod. Nulla commodo aliquet purus nec sollicitudin. Aliquam et volutpat augue. Donec pretium ornare ultrices. Etiam sit amet bibendum orci. Praesent luctus posuere velit. Curabitur iaculis velit sed sapien blandit, vitae fringilla ligula porta. Sed sed cons
+        Pyronear est une association à but non lucratif loi 1901 dont l’objectif
+        est de démocratiser des solutions technologiques sobres et ouvertes de
+        lutte contre les incendies de forêts, au service des écosystèmes et des
+        citoyens. Pour cela, nous co-construisons une solution open source de
+        détection détection précoce, performante, automatique, énergiquement
+        sobre, économique et modulable des départs de feux dans les espaces
+        naturels.
+      </p>
+
+      <p>
+        Pour en savoir plus, rendez-vous sur{' '}
+        <a href="https://pyronear.org/">https://pyronear.org/</a>
       </p>
     </>
   )


### PR DESCRIPTION
A small first PR to remove the dummy text in the `AboutModal` :

<img width="367" alt="image" src="https://github.com/pyronear/pyro-crowdsourcer-react/assets/32538273/44cebdac-f003-4ddc-8409-f87e73d31011">
