### PR TITLE
fix: Fix alignment for desktop footer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/src/global-components/footer/footer.scss
+++ b/src/global-components/footer/footer.scss
@@ -3,12 +3,11 @@
   white-space: pre-wrap;
   display: flex;
   justify-content: center;
-    a {
-      font-family: 'Proxima Nova';
-      font-style: normal;
-      font-weight: 700;
-      font-size: 18px;
-      line-height: 18px;
-      color: #DCE6EA;
-    }
+
+  a {
+    font-family: 'Proxima Nova';
+    font-weight: 700;
+    font-size: 18px;
+    color: #DCE6EA;
   }
+}

--- a/src/global-components/footer/footer.tsx
+++ b/src/global-components/footer/footer.tsx
@@ -1,9 +1,10 @@
 import './footer.scss'
 
-const footerLinkAbout = <a href="https://pyronear.org/" target="_blank" rel="noopener noreferrer">à propos de Pyronear</a>
+const footerLinkAbout = <a href="https://pyronear.org/" target="_blank" rel="noopener noreferrer">À propos de Pyronear</a>
 const footerLinkWebsite = <a href="https://pyronear.org/" target="_blank" rel="noopener noreferrer">Site web</a>
-const footerLinkLegalMentions = <a href="https://pyronear.org/" target="_blank" rel="noopener noreferrer">mentions légales</a>
-const separator = <p> - </p>
+const footerLinkLegalMentions = <a href="https://pyronear.org/" target="_blank" rel="noopener noreferrer">Mentions légales</a>
+const separator = ' - '
 
 export const Footer = (): JSX.Element =>
-    <div id="footer">{footerLinkAbout}{separator}{footerLinkWebsite}{separator}{footerLinkLegalMentions}</div>
+    <div id="footer">
+        <p>{footerLinkAbout}{separator}{footerLinkWebsite}{separator}{footerLinkLegalMentions}</p></div>


### PR DESCRIPTION
- Fixes the alignment for the desktop footer
- I also upper-cased the first letter of each link. It felt more natural but it doesn't match the figma which only has "Site web" with an upper case. I can revert if you prefer the version on figma


![Screenshot 2024-02-24 at 1 07 58 AM](https://github.com/pyronear/pyro-crowdsourcer-react/assets/32538273/b2538508-287d-4807-b26b-fd985ade7194)
