### PR TITLE
chore: Add cspell setup for VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "streetsidesoftware.code-spell-checker",
+        "streetsidesoftware.code-spell-checker-french"
+    ]
+}

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,6 @@
+{
+    "language": "en,fr",
+    "words": [
+        "Pyronear"
+    ]
+}


### PR DESCRIPTION
cSpell has a VSCode extension https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker which is very useful to prevent from doing typos in the code. This is the setup for VSCode.

Later on, they also have GitHub actions or command lines to verify the code doesn't contain any typos.

If you prefer not to add it, that is fine, we can close the PR.