### PR TITLE
fix: Remove valid from state to fix initialisation

### DIFF
--- a/src/generic-components/date-time-picker/DateTimePicker.tsx
+++ b/src/generic-components/date-time-picker/DateTimePicker.tsx
@@ -1,23 +1,17 @@
 import { faCalendarDays, faClock } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import ReactDatePicker from 'react-datepicker'
+import type { DateValidity } from '../../helpers/date'
 
 export interface DatePickerHandle {
   collect: () => Date
 }
 
-export const DateTimePicker = ({ dateTime, onChange }: { dateTime: Date | null, onChange: ({ dateTime, valid }: { dateTime: Date, valid: boolean }) => void }): JSX.Element => {
+export const DateTimePicker = ({ dateTime, onChange, valid }: { dateTime: Date | null, onChange: (dateTime: Date) => void, valid: DateValidity }): JSX.Element => {
   const [dateId, timeId] = ['date-picker', 'time-picker']
 
-  const now = new Date()
-  const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-  const dateMidnight = dateTime === null ? null : new Date(dateTime.getFullYear(), dateTime?.getMonth(), dateTime.getDate())
-
-  const dateIsValid = (dateTime: Date | null): boolean => dateTime !== null && dateMidnight!.getTime() <= todayMidnight.getTime()
-  const timeIsValid = (dateTime: Date | null): boolean => dateTime !== null && (dateMidnight!.getTime() < todayMidnight.getTime() || dateTime.getTime() <= now.getTime())
-
   const _onChange = (dateTime: Date): void => {
-    onChange({ dateTime, valid: dateIsValid(dateTime) && timeIsValid(dateTime) })
+    onChange(dateTime)
   }
 
   return (
@@ -25,14 +19,14 @@ export const DateTimePicker = ({ dateTime, onChange }: { dateTime: Date | null, 
       <div className='field-container'>
         <label htmlFor={dateId}>Date</label>
         <div className='input-container'>
-          <ReactDatePicker dateFormat="dd/MM/yyyy" selected={dateTime} onChange={_onChange} className={`input ${dateIsValid(dateTime) ? 'valid' : 'invalid'}`} id={dateId}/>
+          <ReactDatePicker dateFormat="dd/MM/yyyy" selected={dateTime} onChange={_onChange} className={`input ${valid.date ? 'valid' : 'invalid'}`} id={dateId}/>
           <FontAwesomeIcon icon={faCalendarDays} className="input-icon"/>
         </div>
       </div>
       <div className='field-container'>
         <label htmlFor={timeId}>Heure</label>
         <div className='input-container'>
-          <ReactDatePicker showTimeSelect dateFormat="HH:mm" showTimeSelectOnly selected={dateTime} onChange={_onChange} className={`input ${timeIsValid(dateTime) ? 'valid' : 'invalid'}`} id={timeId} timeFormat="HH:mm" />
+          <ReactDatePicker showTimeSelect dateFormat="HH:mm" showTimeSelectOnly selected={dateTime} onChange={_onChange} className={`input ${valid.time ? 'valid' : 'invalid'}`} id={timeId} timeFormat="HH:mm" />
           <FontAwesomeIcon icon={faClock} className="input-icon"/>
         </div>
       </div>

--- a/src/helpers/date.ts
+++ b/src/helpers/date.ts
@@ -1,0 +1,25 @@
+export interface DateValidity { date: boolean, time: boolean }
+
+/**
+ * Checks whether the given date and time is before today and current time.
+ *
+ * ```ts
+ * const now = new Date(2024, 02, 12, 22, 30); // Apr 12 2024 22:30:00
+ * const pastDate = new Date(2024, 02, 11, 22, 30); // Apr 11 2024 22:30:00
+ * const futureDateToday = new Date(2024, 02, 12, 22, 31); // Apr 12 2024 22:31:00
+ * const futureDateTomorrow = new Date(2024, 02, 13, 22, 30); // Apr 13 2024 22:30:00
+ *
+ * const isDateAndTimeBeforeNow(pastDate); // { date: true, time: true }
+ * const isDateAndTimeBeforeNow(futureDateToday); // { date: true, time: false }
+ * const isDateAndTimeBeforeNow(futureDateTomorrow); // { date: false, time: false }
+ * ```
+ */
+export const isDateAndTimeBeforeNow = (date: Date): DateValidity => {
+  const now = new Date()
+  const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const dateMidnight = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+
+  const isDateValid = dateMidnight.getTime() <= todayMidnight.getTime()
+  const isTimeValid = (dateMidnight.getTime() < todayMidnight.getTime() || date.getTime() <= now.getTime())
+  return { date: isDateValid, time: isTimeValid }
+}

--- a/src/pages/per-picture-info/PictureInfoEditModal.tsx
+++ b/src/pages/per-picture-info/PictureInfoEditModal.tsx
@@ -5,6 +5,7 @@ import { faCircleXmark } from '@fortawesome/free-solid-svg-icons'
 import { ModalInnerComponent } from '../../modals/Modal'
 import { GlobalInfoForm, GlobalInfoData } from '../global-info/GlobalInfo'
 import { PictureInfo } from './PerPictureInfo'
+import { isDateAndTimeBeforeNow } from '../../helpers/date'
 
 export type PictureInfoEditModalContext = PictureInfo & {
   patchInfo: (info: GlobalInfoData) => void
@@ -18,14 +19,16 @@ export const PictureInfoEditModal: ModalInnerComponent = ({ close, context }: { 
     close()
   }
 
-  const onDateTimeChange = ({ dateTime, valid }: { dateTime: Date, valid: boolean }): void => {
+  const dateValidity = isDateAndTimeBeforeNow(date)
+
+  const onDateTimeChange = (dateTime: Date): void => {
     setDate(dateTime)
     // todo : handle validity
   }
 
   return (<>
     <FontAwesomeIcon icon={faCircleXmark} className='closeIcon' onClick={close}/>
-    <GlobalInfoForm date={date} onDateTimeChange={onDateTimeChange} onDepartmentChange={(d) => setDepartment(d as string)} initialDepartment={context.department}/>
+    <GlobalInfoForm date={date} onDateTimeChange={onDateTimeChange} onDepartmentChange={(d) => setDepartment(d as string)} initialDepartment={context.department} dateValidity={dateValidity} />
     <Button text='Valider' onClick={submit}/>
   </>)
 }


### PR DESCRIPTION
Follows https://github.com/pyronear/pyro-crowdsourcer-react/pull/4

It removes `valid` from the state and computes it. The date picker now takes a parameter to indicate whether the date and/or time are valid or not