### PR TITLE
fix: Verify date validity in single picture dialog

### DIFF
--- a/src/helpers/date.test.ts
+++ b/src/helpers/date.test.ts
@@ -1,0 +1,41 @@
+import { isDateAndTimeBeforeNow } from './date'
+
+describe('isDateAndTimeBeforeNow', () => {
+  it('It should return true for a date before today', () => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2020-01-01'))
+
+    const result = isDateAndTimeBeforeNow(new Date('2019-12-31'))
+
+    expect(result).toEqual({ date: true, time: true })
+  })
+  it('It should return false for a date after today', () => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2020-01-01'))
+
+    const result = isDateAndTimeBeforeNow(new Date('2020-01-02'))
+
+    expect(result).toEqual({ date: false, time: false })
+  })
+  it('It should return true for today that is earlier than now', () => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2020-01-01 12:00'))
+
+    const result = isDateAndTimeBeforeNow(new Date('2020-01-01 11:00'))
+
+    expect(result).toEqual({ date: true, time: true })
+  })
+
+  it('It should return date true and time false for today that is later than now', () => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2020-01-01 12:00'))
+
+    const result = isDateAndTimeBeforeNow(new Date('2020-01-01 13:00'))
+
+    expect(result).toEqual({ date: true, time: false })
+  })
+})

--- a/src/pages/per-picture-info/PictureInfoEditModal.tsx
+++ b/src/pages/per-picture-info/PictureInfoEditModal.tsx
@@ -15,20 +15,17 @@ export const PictureInfoEditModal: ModalInnerComponent = ({ close, context }: { 
   const [date, setDate] = useState<Date>(context.datetime)
   const [department, setDepartment] = useState<string | null>(context.department)
   const submit = (): void => {
-    context.patchInfo({ datetime: date, department: department as string, consent: true })
+    context.patchInfo({ datetime: date, department: department!, consent: true })
     close()
   }
 
   const dateValidity = isDateAndTimeBeforeNow(date)
 
-  const onDateTimeChange = (dateTime: Date): void => {
-    setDate(dateTime)
-    // todo : handle validity
-  }
+  const isValid = dateValidity.date && dateValidity.time
 
   return (<>
     <FontAwesomeIcon icon={faCircleXmark} className='closeIcon' onClick={close}/>
-    <GlobalInfoForm date={date} onDateTimeChange={onDateTimeChange} onDepartmentChange={(d) => setDepartment(d as string)} initialDepartment={context.department} dateValidity={dateValidity} />
-    <Button text='Valider' onClick={submit}/>
+    <GlobalInfoForm date={date} onDateTimeChange={setDate} onDepartmentChange={setDepartment} initialDepartment={context.department} dateValidity={dateValidity} />
+    <Button text='Valider' disabled={!isValid} onClick={submit}/>
   </>)
 }


### PR DESCRIPTION
- Checks the date validity in the single photo dialog
- Adds some tests on `isDateAndTimeBeforeNow`

It seems there is an issue with the single select for the department, I cannot modify its value in the single picture dialog. I'll look at it in another PR

https://github.com/pyronear/pyro-crowdsourcer-react/assets/32538273/073d3f2b-e4d7-4377-9377-f6420e84d79a

